### PR TITLE
Add webhook missing url

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -38,7 +38,7 @@ info:
     success callback URL.
 
     Upon confirmation of the transaction, which can take up to 2 hours, we send
-    a notification to the merchant store or website via a [webhook]().
+    a notification to the merchant store or website via a [webhook](#section/Basics/4.-Webhook).
 
     In more detail, this flow has 6 stages:
 


### PR DESCRIPTION
I'm not sure if this is the expected behaviour but I guess it is

On the section **2. Try our flow** there's a `webhook` word which routes to **4. Webhook** section, therefore, I implemented the same behaviour in this case (just because it already has linking logic but doesn't point to any URL)