### PR TITLE
Restructure Libraries section

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -273,7 +273,7 @@ info:
     # APIs
     
     Utrust provides two API's for your use: Stores API and Merchants API.
-    
+
     [Utrust API Reference →](https://docs.api.utrust.com)
 
 paths: false


### PR DESCRIPTION
Why:

* Continuing based on #4 (same tone of speech);
* There's only one library, and adding more there's no need to have copy for
  each one.