### PR TITLE
update demo store link on the crypto docs

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -76,7 +76,7 @@ info:
     You can also use [MetaMask](https://metamask.io/) with some fake ETH, just make sure to change to the Sepolia Testnet, which
     is what we use in our sandbox environment.
 
-    When you are ready, go to our [Sandbox online store](https://demo.store.utrust.com/)
+    When you are ready, go to our [Sandbox online store](https://demo.crypto.xmoney.com/)
     and give it a spin by selecting an item and proceeding to checkout.
     Choose the xMoney payment method.
     Once you proceed to the payment, you will see xMoney Payment Widget.


### PR DESCRIPTION
Update Demo store link that was recently linked: [demo.crypto.xmoney.com](http://demo.crypto.xmoney.com/)